### PR TITLE
Use buildpacks from docker.io instead of gcr.io

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -1,11 +1,11 @@
 description = "Ubuntu 24.04 Noble Numbat tiny image with only Java buildpacks included. To use, specify buildpacks at build time."
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java-native-image:11.9.0"
+  uri = "docker://docker.io/paketobuildpacks/java-native-image:11.9.0"
   version = "11.9.0"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/java:18.5.0"
+  uri = "docker://docker.io/paketobuildpacks/java:18.5.0"
   version = "18.5.0"
 
 [lifecycle]

--- a/smoke.json
+++ b/smoke.json
@@ -1,3 +1,3 @@
 {
-  "procfile" :  "gcr.io/paketo-buildpacks/procfile"
+  "procfile" :  "docker.io/paketobuildpacks/procfile"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Move away from using buildpacks from gcr.io.

## Use Cases
<!-- An explanation of the use cases your change enables -->
>  It has come to my attention that our paketo-buildpacks GCP project is going to be shutdown soon (possibly in as little as two weeks).

https://paketobuildpacks.slack.com/archives/C011S6EL49L/p1743078482582569

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
