### PR TITLE
Add health checker buildpack

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -8,6 +8,10 @@ description = "Ubuntu 24.04 Noble Numbat tiny image with only Java buildpacks in
   uri = "docker://docker.io/paketobuildpacks/java:18.7.0"
   version = "18.7.0"
 
+[[buildpacks]]
+  uri = "docker://docker.io/paketobuildpacks/health-checker:2.10.0"
+  version = "2.10.0"
+
 [lifecycle]
   version = "0.20.9"
 
@@ -17,11 +21,21 @@ description = "Ubuntu 24.04 Noble Numbat tiny image with only Java buildpacks in
     id = "paketo-buildpacks/java-native-image"
     version = "11.11.0"
 
+  [[order.group]]
+    id = "paketo-buildpacks/health-checker"
+    version = "2.10.0"
+    optional = true
+
 [[order]]
 
   [[order.group]]
     id = "paketo-buildpacks/java"
     version = "18.7.0"
+
+  [[order.group]]
+    id = "paketo-buildpacks/health-checker"
+    version = "2.10.0"
+    optional = true
 
 [stack]
   build-image = "docker.io/paketobuildpacks/ubuntu-noble-build-base:0.0.6"


### PR DESCRIPTION
## Summary

Add health-checker buildpack. This is adding it directly to the order groups as an optional buildpack. That means if you do not enable health checking, then it should fail detection and be excluded from the group of buildpacks that is run. Enabling or disabling this buildpack should not cause failures.

## Use Cases

See #57 
