### PR TITLE
Bump stack versions in builder.toml to latest

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -24,9 +24,9 @@ description = "Ubuntu 24.04 Noble Numbat tiny image with only Java buildpacks in
     version = "18.8.0"
 
 [stack]
-  build-image = "docker.io/paketobuildpacks/ubuntu-noble-build-base:0.0.6"
+  build-image = "docker.io/paketobuildpacks/ubuntu-noble-build:0.0.13"
   id = "io.buildpacks.stacks.noble"
-  run-image = "docker.io/paketobuildpacks/ubuntu-noble-run-tiny:0.0.6"
+  run-image = "docker.io/paketobuildpacks/ubuntu-noble-run-tiny:0.0.13"
   run-image-mirrors = []
 
 [[targets]]


### PR DESCRIPTION
- Changed ubuntu-noble-build-base:0.0.6 to ubuntu-noble-build:0.0.13 
- Changed ubuntu-noble-run-tiny:0.0.6 to ubuntu-noble-run-tiny:0.0.13

It appears ubuntu-noble-build-base was changed to ubuntu-noble-build after version 0.0.6.  I'm supposing it should be ubuntu-noble-build now but let me know if that is not true.

## Checklist
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
